### PR TITLE
Use os.tmpdir() for temp-dirs

### DIFF
--- a/osenv.js
+++ b/osenv.js
@@ -2,6 +2,7 @@ var isWindows = process.platform === 'win32'
 var windir = isWindows ? process.env.windir || 'C:\\Windows' : null
 var path = require('path')
 var exec = require('child_process').exec
+var os = require('os')
 
 // looking up envs is a bit costly.
 // Also, sometimes we want to have a fallback
@@ -46,6 +47,10 @@ memo('hostname', function () {
 }, 'hostname')
 
 memo('tmpdir', function () {
+  if (os.tmpdir)
+    return os.tmpdir()
+
+  // old node versions
   var t = isWindows ? 'temp' : 'tmp'
   return process.env.TMPDIR ||
          process.env.TMP ||

--- a/test/unix.js
+++ b/test/unix.js
@@ -9,6 +9,7 @@ if (process.platform === 'win32') {
   return
 }
 var tap = require('tap')
+var os = require('os')
 
 // like unix, but funny
 process.env.USER = 'sirUser'
@@ -22,7 +23,6 @@ process.env.PS1 = '(o_o) $ '
 process.env.EDITOR = 'edit'
 process.env.VISUAL = 'visualedit'
 process.env.SHELL = 'zsh'
-
 
 tap.test('basic unix sanity test', function (t) {
   var osenv = require('../osenv.js')
@@ -45,11 +45,15 @@ tap.test('basic unix sanity test', function (t) {
   var osenv = require('../osenv.js')
   t.equal(osenv.tmpdir(), process.env.TEMP)
 
-  process.env.TEMP = ''
-  delete require.cache[require.resolve('../osenv.js')]
-  var osenv = require('../osenv.js')
-  t.equal(osenv.tmpdir(), '/home/sirUser/tmp')
+  // switch for old node versions
+  if (!os.tmpdir) {
+    process.env.TEMP = ''
+    delete require.cache[require.resolve('../osenv.js')]
+    var osenv = require('../osenv.js')
+    t.equal(osenv.tmpdir(), '/home/sirUser/tmp')
+  }
 
+  process.env.TEMP = ''
   delete require.cache[require.resolve('../osenv.js')]
   var osenv = require('../osenv.js')
   osenv.home = function () { return null }

--- a/test/windows.js
+++ b/test/windows.js
@@ -11,8 +11,9 @@ if (process.platform !== 'win32') {
 
 // load this before clubbing the platform name.
 var tap = require('tap')
+var os = require('os')
 
-process.env.windir = 'C:\\windows'
+process.env.windir = 'c:\\windows'
 process.env.USERDOMAIN = 'some-domain'
 process.env.USERNAME = 'sirUser'
 process.env.USERPROFILE = 'C:\\Users\\sirUser'
@@ -27,8 +28,6 @@ process.env.VISUAL = 'visualedit'
 process.env.ComSpec = 'some-com'
 
 tap.test('basic windows sanity test', function (t) {
-  var osenv = require('../osenv.js')
-
   var osenv = require('../osenv.js')
 
   t.equal(osenv.user(),
@@ -50,16 +49,19 @@ tap.test('basic windows sanity test', function (t) {
   var osenv = require('../osenv.js')
   t.equal(osenv.tmpdir(), process.env.TEMP)
 
-  process.env.TEMP = ''
-  delete require.cache[require.resolve('../osenv.js')]
-  var osenv = require('../osenv.js')
-  t.equal(osenv.tmpdir(), 'C:\\Users\\sirUser\\temp')
+  // switch for old node versions
+  if (!os.tmpdir) {
+    process.env.TEMP = ''
+    delete require.cache[require.resolve('../osenv.js')]
+    var osenv = require('../osenv.js')
+    t.equal(osenv.tmpdir(), 'C:\\Users\\sirUser\\temp')
+  }
 
   process.env.TEMP = ''
   delete require.cache[require.resolve('../osenv.js')]
   var osenv = require('../osenv.js')
   osenv.home = function () { return null }
-  t.equal(osenv.tmpdir(), 'C:\\windows\\temp')
+  t.equal(osenv.tmpdir(), 'c:\\windows\\temp')
 
   t.equal(osenv.editor(), 'edit')
   process.env.EDITOR = ''


### PR DESCRIPTION
The former implementation preferred /home/{username}/tmp on unix
which caused errors for users that had different permissions on
their tmp-folder in their home, like root as owner from a previous
sudo-command.

The new implementation uses a plain os.tmpdir() from node.core.

`os.tmpdir` in node core seems to be essentially the same as this function, with the small difference that not every `process.env`-variable are used on windows

I first thought about checking for the existence of the tmp-dir and then fallback to the /home/{username}/tmp folder but this makes no sense as the system must have the sytsem-/tmp dirs.

This fixes: isaacs/npm#3470
