### PR TITLE
Use os.tmpdir() for temp-dirs

### DIFF
--- a/osenv.js
+++ b/osenv.js
@@ -1,7 +1,7 @@
 var isWindows = process.platform === 'win32'
-var windir = isWindows ? process.env.windir || 'C:\\Windows' : null
 var path = require('path')
 var exec = require('child_process').exec
+var os = require('os')
 
 // looking up envs is a bit costly.
 // Also, sometimes we want to have a fallback
@@ -46,14 +46,7 @@ memo('hostname', function () {
 }, 'hostname')
 
 memo('tmpdir', function () {
-  var t = isWindows ? 'temp' : 'tmp'
-  return process.env.TMPDIR ||
-         process.env.TMP ||
-         process.env.TEMP ||
-         ( exports.home() ? path.resolve(exports.home(), t)
-         : isWindows ? path.resolve(windir, t)
-         : '/tmp'
-         )
+  return os.tmpdir()
 })
 
 memo('home', function () {

--- a/test/unix.js
+++ b/test/unix.js
@@ -23,7 +23,6 @@ process.env.EDITOR = 'edit'
 process.env.VISUAL = 'visualedit'
 process.env.SHELL = 'zsh'
 
-
 tap.test('basic unix sanity test', function (t) {
   var osenv = require('../osenv.js')
 
@@ -46,10 +45,6 @@ tap.test('basic unix sanity test', function (t) {
   t.equal(osenv.tmpdir(), process.env.TEMP)
 
   process.env.TEMP = ''
-  delete require.cache[require.resolve('../osenv.js')]
-  var osenv = require('../osenv.js')
-  t.equal(osenv.tmpdir(), '/home/sirUser/tmp')
-
   delete require.cache[require.resolve('../osenv.js')]
   var osenv = require('../osenv.js')
   osenv.home = function () { return null }

--- a/test/windows.js
+++ b/test/windows.js
@@ -12,7 +12,7 @@ if (process.platform !== 'win32') {
 // load this before clubbing the platform name.
 var tap = require('tap')
 
-process.env.windir = 'C:\\windows'
+process.env.windir = 'c:\\windows'
 process.env.USERDOMAIN = 'some-domain'
 process.env.USERNAME = 'sirUser'
 process.env.USERPROFILE = 'C:\\Users\\sirUser'
@@ -27,8 +27,6 @@ process.env.VISUAL = 'visualedit'
 process.env.ComSpec = 'some-com'
 
 tap.test('basic windows sanity test', function (t) {
-  var osenv = require('../osenv.js')
-
   var osenv = require('../osenv.js')
 
   t.equal(osenv.user(),
@@ -53,13 +51,8 @@ tap.test('basic windows sanity test', function (t) {
   process.env.TEMP = ''
   delete require.cache[require.resolve('../osenv.js')]
   var osenv = require('../osenv.js')
-  t.equal(osenv.tmpdir(), 'C:\\Users\\sirUser\\temp')
-
-  process.env.TEMP = ''
-  delete require.cache[require.resolve('../osenv.js')]
-  var osenv = require('../osenv.js')
   osenv.home = function () { return null }
-  t.equal(osenv.tmpdir(), 'C:\\windows\\temp')
+  t.equal(osenv.tmpdir(), 'c:\\windows\\temp')
 
   t.equal(osenv.editor(), 'edit')
   process.env.EDITOR = ''


### PR DESCRIPTION
The former implementation preferred /home/{username}/tmp on unix
which caused errors for users that had different permissions on
their tmp-folder in their home, like root as owner from a previous
sudo-command.

The new implementation uses a plain os.tmpdir() from node.core.

os.tmpdir in node core seems to be essentially the same as this function, with the small difference that not every process.env-variable are used on windows

I first thought about checking for the existence of the tmp-dir and then fallback to the /home/{username}/tmp folder but this makes no sense as the system must have the sytsem-/tmp dirs.

This fixes: isaacs/npm#3470
