### PR TITLE
Allow users to set a custom editor env variable

### DIFF
--- a/osenv.js
+++ b/osenv.js
@@ -3,6 +3,11 @@ var path = require('path')
 var exec = require('child_process').exec
 var os = require('os')
 
+var customEditor = ''
+exports.setCustomEditorVariable = function(val) {
+  customEditor = val
+}
+
 // looking up envs is a bit costly.
 // Also, sometimes we want to have a fallback
 // Pass in a callback to wait for the fallback on failures
@@ -62,7 +67,8 @@ memo('path', function () {
 })
 
 memo('editor', function () {
-  return process.env.EDITOR ||
+  return process.env[customEditor] ||
+         process.env.EDITOR ||
          process.env.VISUAL ||
          (isWindows ? 'notepad.exe' : 'vi')
 })

--- a/test/unix.js
+++ b/test/unix.js
@@ -19,6 +19,7 @@ process.env.TMP = '/tmp'
 process.env.TEMP = '/temp'
 process.env.PATH = '/opt/local/bin:/usr/local/bin:/usr/bin/:bin'
 process.env.PS1 = '(o_o) $ '
+process.env.CUSTOM_EDITOR = 'custom_edit'
 process.env.EDITOR = 'edit'
 process.env.VISUAL = 'visualedit'
 process.env.SHELL = 'zsh'
@@ -51,6 +52,18 @@ tap.test('basic unix sanity test', function (t) {
   t.equal(osenv.tmpdir(), '/tmp')
 
   t.equal(osenv.editor(), 'edit')
+
+  delete require.cache[require.resolve('../osenv.js')]
+  var osenv = require('../osenv.js')
+  osenv.setCustomEditorVariable('CUSTOM_EDITOR')
+  t.equal(osenv.editor(), 'custom_edit')
+
+  process.env.CUSTOM_EDITOR = ''
+  delete require.cache[require.resolve('../osenv.js')]
+  var osenv = require('../osenv.js')
+  osenv.setCustomEditorVariable('CUSTOM_EDITOR')
+  t.equal(osenv.editor(), 'edit')
+
   process.env.EDITOR = ''
   delete require.cache[require.resolve('../osenv.js')]
   var osenv = require('../osenv.js')

--- a/test/windows.js
+++ b/test/windows.js
@@ -22,6 +22,7 @@ process.env.TMP = 'C:\\tmp'
 process.env.TEMP = 'C:\\temp'
 process.env.Path = 'C:\\Program Files\\;C:\\Binary Stuff\\bin'
 process.env.PROMPT = '(o_o) $ '
+process.env.CUSTOM_EDITOR = 'custom_edit'
 process.env.EDITOR = 'edit'
 process.env.VISUAL = 'visualedit'
 process.env.ComSpec = 'some-com'
@@ -55,6 +56,18 @@ tap.test('basic windows sanity test', function (t) {
   t.equal(osenv.tmpdir(), 'c:\\windows\\temp')
 
   t.equal(osenv.editor(), 'edit')
+
+  delete require.cache[require.resolve('../osenv.js')]
+  var osenv = require('../osenv.js')
+  osenv.setCustomEditorVariable('CUSTOM_EDITOR')
+  t.equal(osenv.editor(), 'custom_edit')
+
+  process.env.CUSTOM_EDITOR = ''
+  delete require.cache[require.resolve('../osenv.js')]
+  var osenv = require('../osenv.js')
+  osenv.setCustomEditorVariable('CUSTOM_EDITOR')
+  t.equal(osenv.editor(), 'edit')
+
   process.env.EDITOR = ''
   delete require.cache[require.resolve('../osenv.js')]
   var osenv = require('../osenv.js')


### PR DESCRIPTION
Many programs allow a custom editor variable to override EDITOR. Now users can
set that on osenv with the following code:

```
var osenv = require('osenv')
osenv.setCustomEditorVariable('MY_EDITOR')

var editor = osenv.editor()
```

If the MY_EDITOR environment variable is set, it will be used. Otherwise we
follow the same rules that osenv has used before.

One confusing point is that if you set the custom editor variable after calling
.editor() the previous result will be cached and this will have no effect.
