### PR TITLE
use `os.tmpdir()` polyfill for more consistent output

### DIFF
--- a/osenv.js
+++ b/osenv.js
@@ -1,7 +1,7 @@
 var isWindows = process.platform === 'win32'
 var path = require('path')
 var exec = require('child_process').exec
-var os = require('os')
+var osTmpdir = require('os-tmpdir')
 
 // looking up envs is a bit costly.
 // Also, sometimes we want to have a fallback
@@ -46,7 +46,7 @@ memo('hostname', function () {
 }, 'hostname')
 
 memo('tmpdir', function () {
-  return os.tmpDir()
+  return osTmpdir()
 })
 
 memo('home', function () {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "os-tmpdir": "^1.0.0"
+  },
   "devDependencies": {
     "tap": "~0.4.9"
   },


### PR DESCRIPTION
The `os.tmpdir()` method has changed a lot between Node versions and it would be nice for users if it were consistent between Node versions. This might even prevent hard to track down bugs.

Node 0.10.38: https://github.com/joyent/node/blob/0b5731a63cc40c4fe9275c79158fe0a5dd4d1609/lib/os.js#L44-L49

io.js 2.0.1: https://github.com/iojs/io.js/blob/6c80e38b014b7be570ffafa91032a6d67d7dd4ae/lib/os.js#L25-L40

From io.js changelog:

> os.tmpdir() is now cross-platform consistent and will no longer returns a path with a trailling slash on any platform

> Updated os.tmpdir on Windows to use the %SystemRoot% or %WINDIR% environment variables instead of the hard-coded value of c:\windows when determining the temporary directory location.

---

https://github.com/sindresorhus/os-tmpdir