### PR TITLE
use `os.homedir()` polyfill for more reliable output

### DIFF
--- a/osenv.js
+++ b/osenv.js
@@ -2,6 +2,7 @@ var isWindows = process.platform === 'win32'
 var path = require('path')
 var exec = require('child_process').exec
 var osTmpdir = require('os-tmpdir')
+var osHomedir = require('os-homedir')
 
 // looking up envs is a bit costly.
 // Also, sometimes we want to have a fallback
@@ -50,9 +51,7 @@ memo('tmpdir', function () {
 })
 
 memo('home', function () {
-  return ( isWindows ? process.env.USERPROFILE
-         : process.env.HOME
-         )
+  return osHomedir()
 })
 
 memo('path', function () {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "test"
   },
   "dependencies": {
+    "os-homedir": "^1.0.0",
     "os-tmpdir": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
https://github.com/sindresorhus/os-homedir

`os.homedir()` was added in io.js 2.3.0 as just reading the environment variables is very fragile, and they're undefined or erroneously overridden in many environments.

The polyfill does more than the current solution to try to infer the home dir.

-

// @iarna 