### PR TITLE
Required callbacks for user & hostname

### DIFF
--- a/osenv.js
+++ b/osenv.js
@@ -24,10 +24,10 @@ function memo (key, lookup, fallback) {
     }
     exports[key] = function (cb) {
       if (cb) process.nextTick(cb.bind(null, null, val))
-      return val
+      else if (!fallback) return val
     }
     if (cb && !falling) process.nextTick(cb.bind(null, null, val))
-    return val
+    if (!cb && !fallback) return val
   }
 }
 

--- a/test/unix.js
+++ b/test/unix.js
@@ -26,9 +26,9 @@ process.env.SHELL = 'zsh'
 tap.test('basic unix sanity test', function (t) {
   var osenv = require('../osenv.js')
 
-  t.equal(osenv.user(), process.env.USER)
+  t.equal(osenv.user(), undefined)
+  t.equal(osenv.hostname(), undefined)
   t.equal(osenv.home(), process.env.HOME)
-  t.equal(osenv.hostname(), process.env.HOSTNAME)
   t.same(osenv.path(), process.env.PATH.split(':'))
   t.equal(osenv.prompt(), process.env.PS1)
   t.equal(osenv.tmpdir(), process.env.TMPDIR)
@@ -67,5 +67,13 @@ tap.test('basic unix sanity test', function (t) {
   var osenv = require('../osenv.js')
   t.equal(osenv.shell(), 'bash')
 
-  t.end()
+  osenv.user(function (err, user) {
+    t.equal(err, null)
+    t.equal(user, process.env.USER)
+    osenv.hostname(function (err, hostname) {
+      t.equal(err, null)
+      t.equal(hostname, process.env.HOSTNAME)
+      t.end()
+    })
+  })
 })

--- a/test/windows.js
+++ b/test/windows.js
@@ -28,10 +28,9 @@ process.env.ComSpec = 'some-com'
 tap.test('basic windows sanity test', function (t) {
   var osenv = require('../osenv.js')
 
-  t.equal(osenv.user(),
-          process.env.USERDOMAIN + '\\' + process.env.USERNAME)
+  t.equal(osenv.user(), undefined)
+  t.equal(osenv.hostname(), undefined)
   t.equal(osenv.home(), process.env.USERPROFILE)
-  t.equal(osenv.hostname(), process.env.COMPUTERNAME)
   t.same(osenv.path(), process.env.Path.split(';'))
   t.equal(osenv.prompt(), process.env.PROMPT)
   t.equal(osenv.tmpdir(), process.env.TMPDIR)
@@ -70,5 +69,13 @@ tap.test('basic windows sanity test', function (t) {
   var osenv = require('../osenv.js')
   t.equal(osenv.shell(), 'cmd')
 
-  t.end()
+  osenv.user(function (err, user) {
+    t.equal(err, null)
+    t.equal(user, process.env.USERDOMAIN + '\\' + process.env.USERNAME)
+    osenv.hostname(function (err, hostname) {
+      t.equal(err, null)
+      t.equal(hostname, process.env.COMPUTERNAME)
+      t.end()
+    })
+  })
 })


### PR DESCRIPTION
This PR proposes a fix to an issue/bug in the osenv API.

Both the `user` and `hostname` methods can optionally fallback to the executables: `whoami` and `hostname`. If a fallback happens, that fallback will be **async**. In other words, depending on the environment `user = osenv.user()` may or may-not work as intended. `osenv.user((err, user) => {}` will always work as intended with the fallback. The important thing here is that the user will not notice the error.

To mitigate this, this PR uses a soft-breaking API. `osenv.user()` and `osenv.hostname()` will always return `undefined`. With a callback it will work, consistently.

An alternative solution to this would be to throw an error if no callback is given and/or write a deprecation warning.