### PR TITLE
Avoid returning outside function

### DIFF
--- a/test/unix.js
+++ b/test/unix.js
@@ -6,7 +6,7 @@ if (process.platform === 'win32') {
   console.log('TAP Version 13\n' +
               '1..0\n' +
               '# Skip unix tests, this is not unix\n')
-  return
+  process.exit(0)
 }
 var tap = require('tap')
 


### PR DESCRIPTION
This is a syntax error in ES6. I know that node wraps the file in a function, but there is no downside to doing it the ES6 way. It will allow osenv to go though Babel without provoking errors.