### PR TITLE
Replacing deprecated os-homedir with homedir-polyfill

### DIFF
--- a/osenv.js
+++ b/osenv.js
@@ -2,7 +2,7 @@ var isWindows = process.platform === 'win32'
 var path = require('path')
 var exec = require('child_process').exec
 var osTmpdir = require('os-tmpdir')
-var osHomedir = require('os-homedir')
+var osHomedir = require('homedir-polyfill')
 
 // looking up envs is a bit costly.
 // Also, sometimes we want to have a fallback

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "~0.14.0"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bind-obj-methods": {
@@ -305,8 +305,8 @@
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "~1.0.5",
-        "mime-types": "~2.1.7"
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "fs-exists-cached": {
@@ -417,6 +417,14 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
+    },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "requires": {
+        "parse-passwd": "^1.0.0"
+      }
     },
     "http-signature": {
       "version": "1.1.1",
@@ -695,6 +703,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -774,7 +783,7 @@
           "requires": {
             "babel-messages": "^6.23.0",
             "babel-runtime": "^6.26.0",
-            "babel-types": "^6.18.0",
+            "babel-types": "^6.26.0",
             "detect-indent": "^4.0.0",
             "jsesc": "^1.3.0",
             "lodash": "^4.17.4",
@@ -787,7 +796,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-runtime": {
@@ -805,8 +814,8 @@
           "dev": true,
           "requires": {
             "babel-runtime": "^6.26.0",
-            "babel-traverse": "^6.18.0",
-            "babel-types": "^6.18.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
             "babylon": "^6.18.0",
             "lodash": "^4.17.4"
           }
@@ -819,7 +828,7 @@
             "babel-code-frame": "^6.26.0",
             "babel-messages": "^6.23.0",
             "babel-runtime": "^6.26.0",
-            "babel-types": "^6.18.0",
+            "babel-types": "^6.26.0",
             "babylon": "^6.18.0",
             "debug": "^2.6.8",
             "globals": "^9.18.0",
@@ -878,7 +887,7 @@
           "dev": true,
           "requires": {
             "md5-hex": "^1.2.0",
-            "mkdirp": "^0.5.0",
+            "mkdirp": "^0.5.1",
             "write-file-atomic": "^1.1.4"
           }
         },
@@ -1025,7 +1034,7 @@
             "is-stream": "^1.1.0",
             "npm-run-path": "^2.0.0",
             "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.1",
+            "signal-exit": "^3.0.0",
             "strip-eof": "^1.0.0"
           },
           "dependencies": {
@@ -1088,7 +1097,7 @@
           "dev": true,
           "requires": {
             "commondir": "^1.0.1",
-            "mkdirp": "^0.5.0",
+            "mkdirp": "^0.5.1",
             "pkg-dir": "^1.0.0"
           }
         },
@@ -1119,7 +1128,7 @@
           "dev": true,
           "requires": {
             "cross-spawn": "^4",
-            "signal-exit": "^3.0.1"
+            "signal-exit": "^3.0.0"
           }
         },
         "fs.realpath": {
@@ -1156,7 +1165,7 @@
           "dev": true,
           "requires": {
             "glob-parent": "^2.0.0",
-            "is-glob": "^2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "glob-parent": {
@@ -1164,7 +1173,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-glob": "^2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "globals": {
@@ -1392,7 +1401,7 @@
           "dev": true,
           "requires": {
             "istanbul-lib-coverage": "^1.1.1",
-            "mkdirp": "^0.5.0",
+            "mkdirp": "^0.5.1",
             "path-parse": "^1.0.5",
             "supports-color": "^3.1.2"
           },
@@ -1414,9 +1423,9 @@
           "requires": {
             "debug": "^3.1.0",
             "istanbul-lib-coverage": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "rimraf": "^2.5.4",
-            "source-map": "^0.5.6"
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.6.1",
+            "source-map": "^0.5.3"
           },
           "dependencies": {
             "debug": {
@@ -1474,7 +1483,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
+            "graceful-fs": "^4.1.2",
             "parse-json": "^2.2.0",
             "pify": "^2.0.0",
             "pinkie-promise": "^2.0.0",
@@ -1505,14 +1514,15 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "js-tokens": "^3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "lru-cache": {
@@ -1611,7 +1621,7 @@
           "requires": {
             "hosted-git-info": "^2.1.4",
             "is-builtin-module": "^1.0.0",
-            "semver": "^5.3.0",
+            "semver": "2 || 3 || 4 || 5",
             "validate-npm-package-license": "^3.0.1"
           }
         },
@@ -1663,7 +1673,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minimist": "0.0.8",
+            "minimist": "~0.0.1",
             "wordwrap": "~0.0.2"
           }
         },
@@ -1708,7 +1718,7 @@
             "glob-base": "^0.3.0",
             "is-dotfile": "^1.0.0",
             "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "parse-json": {
@@ -1747,7 +1757,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
+            "graceful-fs": "^4.1.2",
             "pify": "^2.0.0",
             "pinkie-promise": "^2.0.0"
           }
@@ -1923,7 +1933,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "^0.1.3"
+            "align-text": "^0.1.1"
           }
         },
         "rimraf": {
@@ -1931,7 +1941,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.0.6"
+            "glob": "^7.0.5"
           }
         },
         "semver": {
@@ -1977,12 +1987,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "foreground-child": "^1.5.3",
+            "foreground-child": "^1.5.6",
             "mkdirp": "^0.5.0",
             "os-homedir": "^1.0.1",
-            "rimraf": "^2.5.4",
-            "signal-exit": "^3.0.1",
-            "which": "^1.2.9"
+            "rimraf": "^2.6.2",
+            "signal-exit": "^3.0.2",
+            "which": "^1.3.0"
           }
         },
         "spdx-correct": {
@@ -2086,7 +2096,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "^0.5.6",
+            "source-map": "~0.5.1",
             "uglify-to-browserify": "~1.0.0",
             "yargs": "~3.10.0"
           },
@@ -2150,7 +2160,7 @@
           "dev": true,
           "requires": {
             "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.0"
+            "strip-ansi": "^3.0.1"
           },
           "dependencies": {
             "string-width": {
@@ -2196,7 +2206,7 @@
           "dev": true,
           "requires": {
             "cliui": "^3.2.0",
-            "decamelize": "^1.0.0",
+            "decamelize": "^1.1.1",
             "find-up": "^2.1.0",
             "get-caller-file": "^1.0.1",
             "os-locale": "^2.0.0",
@@ -2215,7 +2225,7 @@
               "dev": true,
               "requires": {
                 "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.0",
+                "strip-ansi": "^3.0.1",
                 "wrap-ansi": "^2.0.0"
               },
               "dependencies": {
@@ -2271,11 +2281,6 @@
       "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
       "dev": true
     },
-    "os-homedir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-      "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac="
-    },
     "os-tmpdir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
@@ -2295,6 +2300,11 @@
       "requires": {
         "own-or": "^1.0.0"
       }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -2349,8 +2359,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
         "isarray": "~1.0.0",
         "process-nextick-args": "~2.0.0",
         "safe-buffer": "~5.1.1",
@@ -2392,14 +2402,15 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.0"
+        "glob": "^7.0.5"
       }
     },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -2474,7 +2485,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "safe-buffer": "~5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {
@@ -2552,9 +2563,9 @@
         "color-support": "^1.1.0",
         "debug": "^2.1.3",
         "diff": "^1.3.2",
-        "escape-string-regexp": "^1.0.2",
-        "glob": "^7.0.0",
-        "js-yaml": "^3.10.0",
+        "escape-string-regexp": "^1.0.3",
+        "glob": "^7.0.5",
+        "js-yaml": "^3.3.1",
         "readable-stream": "^2.1.5",
         "tap-parser": "^5.1.0",
         "unicode-length": "^1.0.0"
@@ -2567,8 +2578,8 @@
           "dev": true,
           "requires": {
             "events-to-array": "^1.0.1",
-            "js-yaml": "^3.10.0",
-            "readable-stream": "^2.1.5"
+            "js-yaml": "^3.2.7",
+            "readable-stream": "^2"
           }
         }
       }
@@ -2580,8 +2591,8 @@
       "dev": true,
       "requires": {
         "events-to-array": "^1.0.1",
-        "js-yaml": "^3.10.0",
-        "minipass": "^2.2.1"
+        "js-yaml": "^3.2.7",
+        "minipass": "^2.2.0"
       }
     },
     "tmatch": {
@@ -2630,8 +2641,8 @@
       "integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
       "dev": true,
       "requires": {
-        "punycode": "^1.4.1",
-        "strip-ansi": "^3.0.0"
+        "punycode": "^1.3.2",
+        "strip-ansi": "^3.0.1"
       }
     },
     "util-deprecate": {
@@ -2655,7 +2666,7 @@
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -2689,7 +2700,7 @@
       "requires": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.0"
+        "signal-exit": "^3.0.2"
       }
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "test"
   },
   "dependencies": {
-    "os-homedir": "^1.0.0",
+    "homedir-polyfill": "^1.0.1",
     "os-tmpdir": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`os-homedir` was deprecated a long while back and it seems all the kids use [homedir-polyfill](https://www.npmjs.com/package/homedir-polyfill) instead. This PR replaces the dependency, which should close #11 